### PR TITLE
feat: send user who invited XP info

### DIFF
--- a/src/handlers/discord-events/guild-create.ts
+++ b/src/handlers/discord-events/guild-create.ts
@@ -1,4 +1,3 @@
-import { error } from 'console';
 import { ActionRowBuilder, AuditLogEvent, ButtonBuilder, ButtonStyle, Client, EmbedBuilder, Events, GuildAuditLogs, GuildMember } from 'discord.js';
 import { isNil } from 'lodash';
 

--- a/src/handlers/discord-events/guild-create.ts
+++ b/src/handlers/discord-events/guild-create.ts
@@ -1,5 +1,5 @@
 import { ActionRowBuilder, AuditLogEvent, ButtonBuilder, ButtonStyle, Client, EmbedBuilder } from 'discord.js';
-import { isNil } from 'lodash';
+import { isNil, noop } from 'lodash';
 
 export default (client: Client) => {
   client.on('guildCreate', async (guild) => {
@@ -54,13 +54,12 @@ export default (client: Client) => {
         privacyPolicyButton
       );
 
-    try {
-      await auditLogUser.send({
+    await auditLogUser.send({
         embeds: [welcomeEmbed],
         components: [welcomeActionRow]
-      });
-    } catch (error) {
-      // No need to catch error here
-    }
+        
+    }).catch(noop)
+
   });
+    
 };

--- a/src/handlers/discord-events/guild-create.ts
+++ b/src/handlers/discord-events/guild-create.ts
@@ -3,10 +3,10 @@ import { isNil } from 'lodash';
 
 export default (client: Client) => {
   client.on(Events.GuildCreate, async (guild) => {
-    let auditLogCheck: GuildAuditLogs<AuditLogEvent.BotAdd>
+    let auditLogCheck: GuildAuditLogs<AuditLogEvent.BotAdd>;
 
     try {
-      auditLogCheck = await guild.fetchAuditLogs({ limit: 1, type: AuditLogEvent.BotAdd});
+      auditLogCheck = await guild.fetchAuditLogs({ limit: 1, type: AuditLogEvent.BotAdd });
     } catch (error) {
       console.log(error);
       return;
@@ -14,7 +14,7 @@ export default (client: Client) => {
     // Checks for the user who has added the bot to the guild. If the user is not found, it will mention the owner of the guild
     
     const auditLogUserId = auditLogCheck.entries.first()?.executorId || guild.ownerId;
-    let auditLogUser: GuildMember
+    let auditLogUser: GuildMember;
 
     try {
       auditLogUser = await guild.members.fetch(auditLogUserId);
@@ -75,7 +75,7 @@ export default (client: Client) => {
         embeds: [welcomeEmbed],
         components: [welcomeActionRow]
 
-      })
+      });
     } catch (error) {
       console.log(error);
       return;

--- a/src/handlers/discord-events/guild-create.ts
+++ b/src/handlers/discord-events/guild-create.ts
@@ -1,0 +1,66 @@
+import { ActionRowBuilder, AuditLogEvent, ButtonBuilder, ButtonStyle, Client, EmbedBuilder } from 'discord.js';
+import { isNil } from 'lodash';
+
+export default (client: Client) => {
+  client.on('guildCreate', async (guild) => {
+    const auditLogCheck = (await guild.fetchAuditLogs({ limit: 1, type: AuditLogEvent.BotAdd})).entries.first()?.executorId || guild.ownerId;
+    // Checks for the user who has added the bot to the guild. If the user is not found, it will mention the owner of the guild
+        
+    const auditLogUser = await guild.members.fetch(auditLogCheck);
+    if (isNil(auditLogCheck)) return;
+
+    const welcomeEmbed = new EmbedBuilder()
+      .setThumbnail(guild.client.user?.displayAvatarURL())
+      .setTitle('Welcome to XP 👋')
+      .setColor('Blue')
+      .setDescription('We are happy, that you chose XP for your server!\nXP is a leveling bot, that allows you to reward your members for their activity.\n\nIf you need help, feel free to join our [support server](https://discord.xp-bot.net)!')
+      .setFields(
+        {
+          name: 'Read our tutorials',
+          value: '- [Roles & Boosts](https://xp-bot.net/blog/guide_roles_and_boosts_1662020313458) \n- [Announcements](https://xp-bot.net/blog/guide_announcements_1660342055312) \n- [Values](https://xp-bot.net/blog/guide_values_1656883362214) \n- [XP, Moderation & Game Modules](https://xp-bot.net/blog/guide_xp__game_modules_1655300944128)',
+          inline: false
+        }
+      );
+    
+    const dashboardButton = new ButtonBuilder()
+      .setLabel('Server Dashboard')
+      .setStyle(ButtonStyle.Link)
+      .setEmoji('🛠️')
+      .setURL(`https://xp-bot.net/servers/${guild.id}`);
+    
+    const announceSettingsButton = new ButtonBuilder()
+      .setLabel('Announcement Settings')
+      .setStyle(ButtonStyle.Link)
+      .setEmoji('🙋')
+      .setURL('https://xp-bot.net/me');
+
+    const premiumButton = new ButtonBuilder()
+      .setLabel('Premium')
+      .setStyle(ButtonStyle.Link)
+      .setEmoji('👑')
+      .setURL('https://xp-bot.net/premium');
+    
+    const privacyPolicyButton = new ButtonBuilder()
+      .setLabel('Privacy Policy')
+      .setStyle(ButtonStyle.Link)
+      .setEmoji('🔖')
+      .setURL('https://xp-bot.net/privacy');
+
+    const welcomeActionRow = new ActionRowBuilder<ButtonBuilder>()
+      .addComponents(
+        dashboardButton,
+        announceSettingsButton,
+        premiumButton,
+        privacyPolicyButton
+      );
+
+    try {
+      await auditLogUser.send({
+        embeds: [welcomeEmbed],
+        components: [welcomeActionRow]
+      });
+    } catch (error) {
+      // No need to catch error here
+    }
+  });
+};

--- a/src/handlers/discord-events/index.ts
+++ b/src/handlers/discord-events/index.ts
@@ -2,9 +2,11 @@ import { Client } from 'discord.js';
 import discordClient from '../../clients/discord-client';
 import interactionCreate from './interaction-create';
 import ready from './ready';
+import guildCreate from './guild-create';
 
 export default (client?: Client) => {
   const c = client || discordClient;
   ready(c);
   interactionCreate(c);
+  guildCreate(c);
 };

--- a/src/handlers/discord-events/interaction-create.ts
+++ b/src/handlers/discord-events/interaction-create.ts
@@ -1,7 +1,7 @@
-import { Client } from 'discord.js';
+import { Client, Events } from 'discord.js';
 
 export default (client: Client) => {
-  client.on('interactionCreate', async (interaction) => {
+  client.on(Events.InteractionCreate, async (interaction) => {
     if (!interaction.isCommand()) return;
 
     // TODO: Better exception handling


### PR DESCRIPTION
- Added `src/handlers/discord-events/guild-create.ts` where user who has invited XP will get DM'ed. If the user information has not been found, it'll DM the guild owner.

- Check has been made to see if information has not been found and if the bot can DM the user so no errors will be displayed